### PR TITLE
Update Build-SukiSU.yml

### DIFF
--- a/.github/workflows/Build-SukiSU.yml
+++ b/.github/workflows/Build-SukiSU.yml
@@ -19,7 +19,7 @@ on:
         type: choice
         description: "配置文件"
         required: true
-        default: oneplus_ace2pro_v
+        default: oneplus_ace2_pro_v
         options:
           - oneplus_nord_ce4_v
           - oneplus_ace_3v_v
@@ -31,7 +31,7 @@ on:
           - oneplus_ace_pro_v
           - oneplus_11_v
           - oneplus_12r_v
-          - oneplus_ace2pro_v
+          - oneplus_ace2_pro_v
           - oneplus_ace3_v
           - oneplus_open_v
           - oneplus12_v


### PR DESCRIPTION
将oneplus_ace2pro_v更改为oneplus_ace2_pro_v，不更改会导致 Ace 2 Pro的内核编译失败